### PR TITLE
Fix validation message for web field

### DIFF
--- a/src/main/java/com/sta/biometric/embebidas/DatosContacto.java
+++ b/src/main/java/com/sta/biometric/embebidas/DatosContacto.java
@@ -42,7 +42,7 @@ public class DatosContacto {
     
     @URL
     @Column(length = 100)
-    @Size(max = 100, message = "El valor no puede exceder los 10 caracteres")
+    @Size(max = 100, message = "El valor no puede exceder los 100 caracteres")
     private String web;
 
 }

--- a/src/test/java/com/sta/biometric/embebidas/DatosContactoTest.java
+++ b/src/test/java/com/sta/biometric/embebidas/DatosContactoTest.java
@@ -1,0 +1,26 @@
+package com.sta.biometric.embebidas;
+
+import org.junit.Test;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ConstraintViolation;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+public class DatosContactoTest {
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    public void webNoDebeExceder100Caracteres() {
+        DatosContacto datos = new DatosContacto();
+        String longWeb = "https://example.com/" + "a".repeat(90);
+        datos.setWeb(longWeb);
+
+        Set<ConstraintViolation<DatosContacto>> violations = validator.validate(datos);
+        boolean found = violations.stream()
+            .anyMatch(v -> "web".equals(v.getPropertyPath().toString())
+                    && v.getMessage().contains("100"));
+        assertTrue("Debe existir una violación por tamaño máximo", found);
+    }
+}


### PR DESCRIPTION
## Summary
- Correct validation message for web field to reflect 100-character limit
- Add unit test ensuring message mentions the correct limit

## Testing
- `mvn -q -DskipTests=false test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894f6f91df4832c8a58bb9e3673a72d