### PR TITLE
Use stored holiday and license flags in attendance evaluation

### DIFF
--- a/src/main/java/com/sta/biometric/qartzJobs/AperturaJornadaJob.java
+++ b/src/main/java/com/sta/biometric/qartzJobs/AperturaJornadaJob.java
@@ -50,9 +50,10 @@ public class AperturaJornadaJob implements Job {
                         System.out.println("  [+] Nueva asistencia creada para: " + empleado.getNombreCompleto());
                     }
 
+                    asistencia.setLicencia(Licencia.tieneLicenciaEnFecha(empleado, hoy));
+                    asistencia.setFeriado(feriado != null);
+
                     inicializarAsistencia(asistencia, empleado, hoy, feriado);
-                    asistencia.setLicencia(asistencia.getConLicencia());
-                    asistencia.setFeriado(asistencia.getEsFeriado());
                     em.merge(asistencia);
 
                     contador++;
@@ -111,11 +112,11 @@ public class AperturaJornadaJob implements Job {
             : 0);
         asistencia.setNota(null);
 
-        if (asistencia.getConLicencia()) {
+        if (asistencia.isLicencia()) {
             asistencia.setEvaluacion(EvaluacionJornada.LICENCIA);
             asistencia.setNota("Licencia activa para hoy.");
             asistencia.setJustificado(true);
-        } else if (asistencia.getEsFeriado()) {
+        } else if (asistencia.isFeriado()) {
             asistencia.setEvaluacion(EvaluacionJornada.FERIADO);
             asistencia.setNota("Feriado: " + (feriado != null ? feriado.getMotivo() : "Sin motivo especificado"));
             asistencia.setJustificado(true);


### PR DESCRIPTION
## Summary
- Drop `getEsFeriado` and `getConLicencia` in `AuditoriaRegistros` and rely on stored `feriado` and `licencia` fields
- Update `AperturaJornadaJob` and `consolidarDesdeRegistros` to set these flags before evaluating attendance

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6895e8ce0b2c832c9b40579000175851