### PR TITLE
feat: persist holiday note in attendance

### DIFF
--- a/src/main/java/com/sta/biometric/qartzJobs/AperturaJornadaJob.java
+++ b/src/main/java/com/sta/biometric/qartzJobs/AperturaJornadaJob.java
@@ -110,6 +110,8 @@ public class AperturaJornadaJob implements Job {
             ? TiempoUtils.calcularMinutosLocalTime(entrada, salida)
             : 0);
         asistencia.setNota(null);
+        asistencia.setObservacionFeriado(
+            feriado != null ? feriado.getTipo().toUpperCase() + " - " + feriado.getMotivo() : null);
 
         if (asistencia.getConLicencia()) {
             asistencia.setEvaluacion(EvaluacionJornada.LICENCIA);


### PR DESCRIPTION
## Summary
- persist `observacionFeriado` in `AuditoriaRegistros`
- set holiday note during job initialization and record consolidation

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6895e8d16f04832c8d91cd891708ce2c