### PR TITLE
Persist evaluacion field for ColeccionRegistros

### DIFF
--- a/src/main/java/com/sta/biometric/modelo/ColeccionRegistros.java
+++ b/src/main/java/com/sta/biometric/modelo/ColeccionRegistros.java
@@ -17,7 +17,7 @@ import lombok.*;
  * 
  * 
  * Entidad que representa un registro individual (antes era embebido).
- * Ahora cada ColeccionRegistros sabe cómo evaluarse a sí mismo
+ * Ahora cada ColeccionRegistros sabe cÃ³mo evaluarse a sÃ­ mismo
  * a partir del turno asignado al empleado y la hora de fichada.
  * 
  * 
@@ -46,14 +46,14 @@ public class ColeccionRegistros extends Identifiable {
     private AuditoriaRegistros asistenciaDiaria;
 
     /**
-     * Fecha y hora exacta en que se registró la fichada.
+     * Fecha y hora exacta en que se registrÃ³ la fichada.
      */
     @ReadOnly
     private LocalDate fecha;
     
  
     /**
-    * metodo adicional para mostrar el dia de la semana en espa�ol.
+    * metodo adicional para mostrar el dia de la semana en español.
      */
     @Transient
     @ReadOnly
@@ -93,7 +93,7 @@ public class ColeccionRegistros extends Identifiable {
     private String evaluacion;
     
     @Transient
-    public String getEvaluacion() {
+    public String calcularEvaluacion() {
     	
         if (asistenciaDiaria == null) {
             return "ERROR DE REGISTRO - SIN ASISTENCIA DIARIA";
@@ -156,8 +156,12 @@ public class ColeccionRegistros extends Identifiable {
     }
 
     
+    public String getEvaluacion() {
+        return evaluacion;
+    }
+
     @PrePersist @PreUpdate
     private void preGuardarActualizar() {
-        setEvaluacion(getEvaluacion());
+        setEvaluacion(calcularEvaluacion());
      }
 }


### PR DESCRIPTION
## Summary
- Rename inline evaluation logic to `calcularEvaluacion` and expose stored `evaluacion` via a simple getter
- Recompute evaluation on `@PrePersist`/`@PreUpdate` so the field stays updated

## Testing
- `mvn -q test` *(fails: Could not transfer artifact maven-resources-plugin:3.3.1 - Network is unreachable)*
- `mvn -q -o test` *(fails: Cannot access central in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_6895e8d3dd88832cb6f23673671fd99b