### PR TITLE
Deduplicate attendance records by timestamp

### DIFF
--- a/src/main/java/com/sta/biometric/acciones/ImportarRegistrosAction.java
+++ b/src/main/java/com/sta/biometric/acciones/ImportarRegistrosAction.java
@@ -18,7 +18,7 @@ import com.sta.biometric.modelo.*;
 import com.sta.biometric.servicios.*;
 
 /**
- * Acción personalizada para importar registros de fichadas desde un archivo Excel.
+ * AcciÃ³n personalizada para importar registros de fichadas desde un archivo Excel.
  * Refactorizada para trabajar con las nuevas clases `AuditoriaRegistros` y `ColeccionRegistros`
  * utilizando `LocalDate` y `LocalTime` en lugar de `LocalDateTime`.
  */
@@ -32,7 +32,7 @@ public class ImportarRegistrosAction extends ViewBaseAction {
         // 1) Obtener archivo cargado desde la vista
         XFileItem fichero = (XFileItem) getView().getValue("fichero");
         if (fichero == null) {
-            addError("Debe seleccionar un archivo válido.");
+            addError("Debe seleccionar un archivo vÃ¡lido.");
             return;
         }
 
@@ -60,10 +60,10 @@ public class ImportarRegistrosAction extends ViewBaseAction {
                     // === PARSEO DE DATOS ===
                     LocalDate fecha = parsearFecha(row.getCell(columnas.colFecha), formatoCorto, formatoLargo);
                     LocalTime hora = parsearHora(row.getCell(columnas.colHora));
-                    if (fecha == null || hora == null) throw new IllegalArgumentException("Fecha u hora inválida");
+                    if (fecha == null || hora == null) throw new IllegalArgumentException("Fecha u hora invÃ¡lida");
 
                     String userId = getCellValueAsString(row.getCell(columnas.colUserId)).trim();
-                    if (userId.isEmpty()) throw new IllegalArgumentException("UserId vacío");
+                    if (userId.isEmpty()) throw new IllegalArgumentException("UserId vacÃ­o");
 
                     Personal empleado = em.createQuery(
                         "SELECT e FROM Personal e WHERE e.userId = :userId", Personal.class)
@@ -81,7 +81,7 @@ public class ImportarRegistrosAction extends ViewBaseAction {
                     TipoMovimiento tipo = InterpreteFichadasService.deducirTipoMovimiento(descripcion);
                     if (tipo == null) throw new IllegalArgumentException("No se pudo deducir tipo de movimiento");
 
-                    // === CREACIO�N DEL REGISTRO ===
+                    // === CREACIO“N DEL REGISTRO ===
                     ColeccionRegistros cr = new ColeccionRegistros();
                     cr.setFecha(fecha);
                     cr.setHora(hora);
@@ -99,9 +99,7 @@ public class ImportarRegistrosAction extends ViewBaseAction {
 
             workbook.close();
 
-            // === CONSOLIDACIO�N EN AUDITORIAREGISTROS ===
-            for (Map.Entry<Pair<Personal, LocalDate>, List<ColeccionRegistros>> entry : porEmpleadoYFecha.entrySet()) {
-                try {
+                        auditoria.agregarRegistro(r); // sin duplicados fecha/hora
                     Personal empleado = entry.getKey().getLeft();
                     LocalDate fecha = entry.getKey().getRight();
                     List<ColeccionRegistros> registros = entry.getValue();
@@ -137,11 +135,11 @@ public class ImportarRegistrosAction extends ViewBaseAction {
 
             closeDialog();
             getView().refresh();
-            addMessage("Importaci�n finalizada correctamente.");
+            addMessage("Importación finalizada correctamente.");
         }
     }
 
-    // ===================== MÉTODOS AUXILIARES =====================
+    // ===================== MÃ‰TODOS AUXILIARES =====================
 
     private LocalDate parsearFecha(Cell cell, DateTimeFormatter corto, DateTimeFormatter largo) {
         try {
@@ -173,7 +171,7 @@ public class ImportarRegistrosAction extends ViewBaseAction {
             return LocalDate.parse(texto); // fallback
 
         } catch (Exception e) {
-            addWarning("Fecha inválida: '" + getCellValueAsString(cell) + "'");
+            addWarning("Fecha invÃ¡lida: '" + getCellValueAsString(cell) + "'");
             return null;
         }
     }

--- a/src/main/java/com/sta/biometric/modelo/AuditoriaRegistros.java
+++ b/src/main/java/com/sta/biometric/modelo/AuditoriaRegistros.java
@@ -38,12 +38,12 @@ import lombok.*;
     		 @RowStyle(style = "estilo-verde-intenso",  property = "evaluacion", value = "COMPLETA"),              // Jornada cerrada correctamente
     		 @RowStyle(style = "estilo-amarillo-claro", property = "evaluacion", value = "INCOMPLETA"),            // Faltan fichadas para cerrar
     		 @RowStyle(style = "estilo-rojo-intenso",   property = "evaluacion", value = "AUSENTE"),               // Sin registros
-    		 @RowStyle(style = "estilo-rojo-claro",     property = "evaluacion", value = "LICENCIA"),              // Día justificado con licencia
-    		 @RowStyle(style = "estilo-azul-claro",     property = "evaluacion", value = "FERIADO"),               // Feriado común
+    		 @RowStyle(style = "estilo-rojo-claro",     property = "evaluacion", value = "LICENCIA"),              // DÃ­a justificado con licencia
+    		 @RowStyle(style = "estilo-azul-claro",     property = "evaluacion", value = "FERIADO"),               // Feriado comÃºn
     		 @RowStyle(style = "estilo-azul-intenso",   property = "evaluacion", value = "FERIADO_TRABAJADO"),     // Feriado pero con actividad
-    		 @RowStyle(style = "estilo-verde-claro",    property = "evaluacion", value = "DIA_NO_LABORAL"),        // Día no laborable según turno
+    		 @RowStyle(style = "estilo-verde-claro",    property = "evaluacion", value = "DIA_NO_LABORAL"),        // DÃ­a no laborable segÃºn turno
     		 @RowStyle(style = "estilo-verde-claro",    property = "evaluacion", value = "SIN_TURNO_ASIGNADO"),    // No hay turno configurado
-    		 @RowStyle(style = "estilo-rojo-intenso",   property = "evaluacion", value = "SIN_DATOS")             // Sin información básica
+    		 @RowStyle(style = "estilo-rojo-intenso",   property = "evaluacion", value = "SIN_DATOS")             // Sin informaciÃ³n bÃ¡sica
      },
      properties = "empleado.sucursal.nombre, empleado.nombreCompleto, fecha, horario, evaluacion",
      defaultOrder = "${fecha} desc, ${empleado.sucursal.nombre} asc, ${empleado.nombreCompleto} asc"
@@ -126,7 +126,25 @@ public class AuditoriaRegistros extends Identifiable {
     @TextArea
     private String nota;
 
-// ===================== ME‰TODOS PRINCIPALES =====================
+    /**
+     * Agrega un registro a la lista deduplicando por fecha y hora.
+     * Si ya existe un registro con la misma combinacion, se reemplaza.
+     *
+     * @param registro Nuevo registro a incorporar
+     */
+    public void agregarRegistro(ColeccionRegistros registro) {
+        if (registro == null) return;
+
+        registros.removeIf(r ->
+            Objects.equals(r.getFecha(), registro.getFecha()) &&
+            Objects.equals(r.getHora(), registro.getHora())
+        );
+
+        registro.setAsistenciaDiaria(this);
+        registros.add(registro);
+    }
+
+// ===================== MEâ€°TODOS PRINCIPALES =====================
 
     public void consolidarDesdeRegistros() {
         if (empleado == null || fecha == null) return;
@@ -327,6 +345,6 @@ public class AuditoriaRegistros extends Identifiable {
     public String getTurnoPlanificado() {
         return (empleado != null && fecha != null)
             ? TiempoUtils.formatearFecha(fecha) + " - " + empleado.getTurnoDescripcionParaFecha(fecha)
-            : "Sin información";
+            : "Sin informaciÃ³n";
     }
 }

--- a/src/main/java/com/sta/biometric/rest/AsistenciaEndpoint.java
+++ b/src/main/java/com/sta/biometric/rest/AsistenciaEndpoint.java
@@ -186,9 +186,8 @@ public class AsistenciaEndpoint {
             : InterpreteFichadasService.deducirTipoMovimiento(body.getDescripcionTipo());
         reg.setTipoMovimiento(tipo);
 
-        /* 5.2 Asociar a la auditoría */
-        reg.setAsistenciaDiaria(dia);
-        dia.getRegistros().add(reg);   // relación bidireccional
+        /* 5.2 Asociar a la auditoria (dedup fecha/hora) */
+        dia.agregarRegistro(reg);   // relacion bidireccional y sin duplicados
 
         /* 6. Consolidar */
         dia.consolidarDesdeRegistros();

--- a/src/main/java/com/sta/biometric/servicios/AsistenciaDiariaService.java
+++ b/src/main/java/com/sta/biometric/servicios/AsistenciaDiariaService.java
@@ -11,22 +11,17 @@ import com.sta.biometric.modelo.*;
 /**
  * Servicio para consolidar registros diarios de asistencia de los empleados.
  * 
- * Refactorizado para utilizar EvaluacionJornada como único resultado final.
- */
-	public class AsistenciaDiariaService {
-
-    /**
-     * Consolida la asistencia de un empleado en una fecha especafica
-     * a partir de sus registros del dia.
-     * @param hora 
-   /*
-    * 
-    * @param empleado
-    * @param fecha
-    * @param hora
-    * @param registrosDelDia
-    */
-    public static void consolidarDia(Personal empleado, LocalDate fecha, LocalTime hora, List<ColeccionRegistros> registrosDelDia) {
+public class AsistenciaDiariaService {
+     * Consolida la asistencia de un empleado en una fecha especifica a partir de sus registros del dia.
+     * Los registros duplicados (misma fecha y hora) son reemplazados.
+     *
+     * @param empleado Empleado a procesar
+     * @param fecha Fecha de la asistencia
+     * @param hora Hora de consolidacion (opcional)
+     * @param registrosDelDia Registros capturados en el dia
+     */
+ // Si hay registros nuevos, se agregan deduplicando por fecha/hora
+                asistencia.agregarRegistro(registro);
         EntityManager em = XPersistence.getManager();
 
         if (empleado == null || fecha == null) return;
@@ -59,7 +54,7 @@ import com.sta.biometric.modelo.*;
 
 
     /**
-     * Busca la asistencia diaria de un empleado para una fecha espec�fica.
+     * Busca la asistencia diaria de un empleado para una fecha específica.
      * Si no existe, retorna null.
      */
     private static AuditoriaRegistros buscarAsistenciaDiaria(Personal empleado, LocalDate fecha) {


### PR DESCRIPTION
## Summary
- Add `agregarRegistro` in `AuditoriaRegistros` to replace records with the same date/time
- Consolidate and service callers now use the new method, removing duplicates automatically
- Document the deduplication strategy across service, REST endpoint, and import action

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6895e8d96654832c824d259a68fafa12