### PR TITLE
Add listener to consolidate daily attendance after record changes

### DIFF
--- a/src/main/java/com/sta/biometric/modelo/ColeccionRegistros.java
+++ b/src/main/java/com/sta/biometric/modelo/ColeccionRegistros.java
@@ -17,7 +17,8 @@ import lombok.*;
  * 
  * 
  * Entidad que representa un registro individual (antes era embebido).
- * Ahora cada ColeccionRegistros sabe cómo evaluarse a sí mismo
+@EntityListeners(ColeccionRegistrosListener.class)
+ * Ahora cada ColeccionRegistros sabe cÃ³mo evaluarse a sÃ­ mismo
  * a partir del turno asignado al empleado y la hora de fichada.
  * 
  * 
@@ -46,14 +47,14 @@ public class ColeccionRegistros extends Identifiable {
     private AuditoriaRegistros asistenciaDiaria;
 
     /**
-     * Fecha y hora exacta en que se registró la fichada.
+     * Fecha y hora exacta en que se registrÃ³ la fichada.
      */
     @ReadOnly
     private LocalDate fecha;
     
  
     /**
-    * metodo adicional para mostrar el dia de la semana en espa�ol.
+    * metodo adicional para mostrar el dia de la semana en español.
      */
     @Transient
     @ReadOnly

--- a/src/main/java/com/sta/biometric/modelo/ColeccionRegistrosListener.java
+++ b/src/main/java/com/sta/biometric/modelo/ColeccionRegistrosListener.java
@@ -1,0 +1,31 @@
+package com.sta.biometric.modelo;
+
+import javax.persistence.PostPersist;
+import javax.persistence.PostUpdate;
+
+import org.openxava.jpa.XPersistence;
+
+/**
+ * Listener de entidad para ColeccionRegistros que consolida la asistencia diaria
+ * luego de insertar o actualizar un registro.
+ */
+public class ColeccionRegistrosListener {
+
+    @PostPersist
+    public void postPersist(ColeccionRegistros registro) {
+        consolidar(registro);
+    }
+
+    @PostUpdate
+    public void postUpdate(ColeccionRegistros registro) {
+        consolidar(registro);
+    }
+
+    private void consolidar(ColeccionRegistros registro) {
+        AuditoriaRegistros asistenciaDiaria = registro.getAsistenciaDiaria();
+        if (asistenciaDiaria != null) {
+            asistenciaDiaria.consolidarDesdeRegistros();
+            XPersistence.getManager().merge(asistenciaDiaria);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ColeccionRegistrosListener` to trigger consolidation on save
- register listener on `ColeccionRegistros`

## Testing
- `mvn -q -DskipTests=false test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6895e8d9eb38832c938e3f0b7c05b4f4